### PR TITLE
Revamp bank event monitor UI and formatting

### DIFF
--- a/app/src/components/BankEventStatsList.tsx
+++ b/app/src/components/BankEventStatsList.tsx
@@ -2,46 +2,61 @@ import { useMemo, useState } from "react";
 import type { FetchedBank } from "../services/api";
 import type { BankEventStats, EventTotals } from "../types/events";
 import { createEmptyBankEventStats } from "../types/events";
-import { formatTokenAmount } from "../lib/format";
+import { formatTokenAmountFixed } from "../lib/format";
 
 interface BankEventStatsListProps {
   banks: FetchedBank[];
   stats: Record<string, BankEventStats>;
 }
 
-const renderPrimary = (stat: EventTotals, decimals: number) => (
-  <div className="space-y-1">
-    <div className="font-mono text-sm">
-      {formatTokenAmount(stat.total, decimals)}
-    </div>
-    <div className="text-xs text-gray-500">
-      {stat.count} {stat.count === 1 ? "event" : "events"}
-    </div>
-    {stat.total !== 0n && (
-      <div className="text-[0.65rem] text-gray-400 font-mono">
-        raw: {stat.total.toString()}
-      </div>
-    )}
-  </div>
-);
+interface StatPanelProps {
+  label: string;
+  totals: EventTotals;
+  decimals: number;
+  accentClass: string;
+  flaggedLabel?: string;
+}
 
-const renderFlagged = (stat: EventTotals, decimals: number) => (
-  <div className="space-y-1">
-    <div className="font-mono text-sm">
-      {stat.flaggedCount > 0
-        ? formatTokenAmount(stat.flaggedTotal, decimals)
-        : "0"}
-    </div>
-    <div className="text-xs text-gray-500">
-      {stat.flaggedCount} {stat.flaggedCount === 1 ? "event" : "events"}
-    </div>
-    {stat.flaggedCount > 0 && (
-      <div className="text-[0.65rem] text-gray-400 font-mono">
-        raw: {stat.flaggedTotal.toString()}
+const StatPanel: React.FC<StatPanelProps> = ({
+  label,
+  totals,
+  decimals,
+  accentClass,
+  flaggedLabel,
+}) => {
+  const eventLabel = totals.count === 1 ? "event" : "events";
+  const flaggedEventLabel =
+    totals.flaggedCount === 1 ? "event" : "events";
+  const flaggedSummary = flaggedLabel
+    ? totals.flaggedCount > 0
+      ? `${flaggedLabel}: ${formatTokenAmountFixed(
+          totals.flaggedTotal,
+          decimals,
+        )} • ${totals.flaggedCount.toLocaleString()} ${flaggedEventLabel}`
+      : `${flaggedLabel}: none`
+    : null;
+
+  return (
+    <div className="rounded-xl border border-cyan-500/10 bg-slate-950/40 p-4 shadow-[0_0_20px_rgba(14,165,233,0.15)] transition-transform duration-200 hover:-translate-y-1 hover:shadow-[0_0_30px_rgba(236,72,153,0.25)]">
+      <div
+        className={`text-xs font-semibold uppercase tracking-[0.2em] ${accentClass}`}
+      >
+        {label}
       </div>
-    )}
-  </div>
-);
+      <div className="mt-3 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <span className="font-mono text-lg text-cyan-50 tabular-nums min-w-[15ch]">
+          {formatTokenAmountFixed(totals.total, decimals)}
+        </span>
+        <span className="text-xs text-cyan-200/70">
+          {totals.count.toLocaleString()} {eventLabel}
+        </span>
+      </div>
+      {flaggedSummary && (
+        <div className="mt-2 text-xs text-orange-200/80">{flaggedSummary}</div>
+      )}
+    </div>
+  );
+};
 
 export const BankEventStatsList: React.FC<BankEventStatsListProps> = ({
   banks,
@@ -60,88 +75,94 @@ export const BankEventStatsList: React.FC<BankEventStatsListProps> = ({
   }, [banks, search]);
 
   return (
-    <div className="space-y-4">
-      <button
-        onClick={() => setCollapsed((current) => !current)}
-        className="px-4 py-2 bg-blue-600 text-white rounded"
-      >
-        {collapsed ? "Show Banks" : "Hide Banks"}
-      </button>
+    <div className="space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          onClick={() => setCollapsed((current) => !current)}
+          className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-cyan-500/90 via-blue-500/80 to-pink-500/80 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-pink-500/20 transition hover:-translate-y-0.5 hover:shadow-pink-500/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-pink-300/60"
+        >
+          {collapsed ? "Show Banks" : "Hide Banks"}
+        </button>
 
-      {!collapsed && (
-        <div className="space-y-3">
+        {!collapsed && (
           <input
             type="text"
             placeholder="Search by token name…"
             value={search}
             onChange={(event) => setSearch(event.target.value)}
-            className="w-full px-3 py-2 border rounded"
+            className="w-full rounded-xl border border-cyan-500/30 bg-slate-950/60 px-3 py-2 text-sm text-cyan-100 placeholder:text-cyan-200/40 focus:border-pink-400 focus:outline-none focus:ring-2 focus:ring-pink-400/40 sm:max-w-xs"
           />
+        )}
+      </div>
 
-          <div className="overflow-x-auto">
-            <table className="min-w-full border rounded bg-white">
-              <thead className="bg-gray-100 text-left text-xs uppercase tracking-wide text-gray-600">
-                <tr>
-                  <th className="px-3 py-2">Token</th>
-                  <th className="px-3 py-2">Deposits</th>
-                  <th className="px-3 py-2">Borrows</th>
-                  <th className="px-3 py-2">Withdrawals</th>
-                  <th className="px-3 py-2">Withdraw All*</th>
-                  <th className="px-3 py-2">Repays</th>
-                  <th className="px-3 py-2">Repay All*</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredBanks.length === 0 && (
-                  <tr>
-                    <td
-                      colSpan={7}
-                      className="px-3 py-6 text-center text-sm text-gray-500"
-                    >
-                      No banks match your search.
-                    </td>
-                  </tr>
-                )}
+      {!collapsed && (
+        <div className="space-y-5">
+          {filteredBanks.length === 0 ? (
+            <div className="rounded-2xl border border-pink-500/30 bg-slate-950/40 p-6 text-center text-sm text-pink-200/80">
+              No banks match your search.
+            </div>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {filteredBanks.map((bank) => {
+                const key = bank.bankPubkey.toBase58();
+                const bankStats = stats[key] ?? createEmptyBankEventStats();
+                const decimals = bank.bankAcc?.mintDecimals ?? 0;
 
-                {filteredBanks.map((bank) => {
-                  const key = bank.bankPubkey.toBase58();
-                  const bankStats = stats[key] ?? createEmptyBankEventStats();
-                  const decimals = bank.bankAcc?.mintDecimals ?? 0;
-
-                  return (
-                    <tr key={key} className="border-t">
-                      <td className="px-3 py-2 font-medium text-sm">
-                        <div>{bank.tokenName}</div>
-                        <div className="text-xs text-gray-500 font-mono">
+                return (
+                  <div
+                    key={key}
+                    className="group relative overflow-hidden rounded-2xl border border-cyan-500/20 bg-slate-950/60 p-5 shadow-[0_0_30px_rgba(14,165,233,0.15)] transition-transform duration-300 hover:-translate-y-1 hover:shadow-[0_0_45px_rgba(236,72,153,0.35)]"
+                  >
+                    <div className="pointer-events-none absolute inset-x-4 top-0 h-px bg-gradient-to-r from-transparent via-cyan-400/60 to-transparent" />
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h3 className="text-lg font-semibold text-pink-200">
+                          {bank.tokenName}
+                        </h3>
+                        <p className="mt-1 break-all font-mono text-[0.65rem] text-cyan-200/60">
                           {key}
-                        </div>
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderPrimary(bankStats.deposit, decimals)}
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderPrimary(bankStats.borrow, decimals)}
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderPrimary(bankStats.withdraw, decimals)}
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderFlagged(bankStats.withdraw, decimals)}
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderPrimary(bankStats.repay, decimals)}
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderFlagged(bankStats.repay, decimals)}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+                        </p>
+                      </div>
+                      <span className="rounded-full border border-cyan-500/30 bg-cyan-500/10 px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-widest text-cyan-200/80">
+                        {decimals} dec
+                      </span>
+                    </div>
 
-          <p className="text-xs text-gray-500">
+                    <div className="mt-4 grid gap-3">
+                      <StatPanel
+                        label="Deposits"
+                        totals={bankStats.deposit}
+                        decimals={decimals}
+                        accentClass="text-cyan-300"
+                      />
+                      <StatPanel
+                        label="Borrows"
+                        totals={bankStats.borrow}
+                        decimals={decimals}
+                        accentClass="text-blue-300"
+                      />
+                      <StatPanel
+                        label="Withdrawals"
+                        totals={bankStats.withdraw}
+                        decimals={decimals}
+                        accentClass="text-pink-300"
+                        flaggedLabel="Withdraw All"
+                      />
+                      <StatPanel
+                        label="Repays"
+                        totals={bankStats.repay}
+                        decimals={decimals}
+                        accentClass="text-orange-300"
+                        flaggedLabel="Repay All"
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <p className="text-xs text-cyan-200/60">
             * Withdraw All / Repay All events are tracked separately because the
             reported amount may not reflect the final settled amount.
           </p>

--- a/app/src/lib/format.ts
+++ b/app/src/lib/format.ts
@@ -32,3 +32,26 @@ export const formatTokenAmount = (
       groupSize: 3,
     });
 };
+
+export const formatTokenAmountFixed = (
+  raw: bigint,
+  decimals: number,
+  fractionDigits = 4,
+): string => {
+  if (fractionDigits < 0) {
+    throw new Error("fractionDigits must be non-negative");
+  }
+
+  if (raw === 0n) {
+    return `0.${"0".repeat(fractionDigits)}`;
+  }
+
+  const divisor = decimals > 0 ? new BigNumber(10).pow(decimals) : new BigNumber(1);
+  const normalized = new BigNumber(raw.toString()).dividedBy(divisor);
+
+  return normalized.toFormat(fractionDigits, BigNumber.ROUND_DOWN, {
+    groupSeparator: ",",
+    decimalSeparator: ".",
+    groupSize: 3,
+  });
+};

--- a/app/src/pages/BankEventMonitorPage.tsx
+++ b/app/src/pages/BankEventMonitorPage.tsx
@@ -9,7 +9,7 @@ import {
   type EventTotals,
 } from "../types/events";
 import { BankEventStatsList } from "../components/BankEventStatsList";
-import { formatTokenAmount } from "../lib/format";
+import { formatTokenAmountFixed } from "../lib/format";
 
 const DEFAULT_HTTP_TEMPLATE = "https://mrgn.rpcpool.com/<API_KEY>";
 const DEFAULT_WS_TEMPLATE = "wss://mrgn.rpcpool.com/<API_KEY>";
@@ -605,22 +605,24 @@ export function BankEventMonitorPage({
     );
   }, [stats]);
 
-  const lastEventDisplay = useMemo(() => {
+  const lastEventDetails = useMemo(() => {
     if (!lastEvent) {
       return null;
     }
 
     const bank = bankByPubkey.get(lastEvent.bankKey);
     const decimals = bank?.bankAcc?.mintDecimals ?? 0;
-    const formattedAmount = formatTokenAmount(lastEvent.amount, decimals, {
-      maxFractionDigits: 6,
-    });
 
-    return `${lastEvent.kind.toUpperCase()} event for ${
-      bank?.tokenName ?? lastEvent.bankKey
-    } — ${formattedAmount}${
-      lastEvent.flagged ? " (withdraw/repay all)" : ""
-    } at slot ${lastEvent.slot}`;
+    return {
+      kind: lastEvent.kind,
+      kindLabel: lastEvent.kind.toUpperCase(),
+      bankLabel: bank?.tokenName ?? lastEvent.bankKey,
+      bankKey: lastEvent.bankKey,
+      amount: formatTokenAmountFixed(lastEvent.amount, decimals),
+      flagged: lastEvent.flagged,
+      slot: lastEvent.slot,
+      timestampText: new Date(lastEvent.timestamp).toLocaleString(),
+    };
   }, [bankByPubkey, lastEvent]);
 
   const statusLabel = useMemo(() => {
@@ -638,86 +640,213 @@ export function BankEventMonitorPage({
     }
   }, [status]);
 
-  return (
-    <div className="space-y-6">
-      <section className="space-y-3">
-        <h1 className="text-2xl font-semibold">Geyser Event Monitor</h1>
-        <p className="text-sm text-gray-600">
-          Paste your Geyser API key and press Start to subscribe to marginfi
-          lending account events. The monitor listens for deposit, borrow,
-          withdraw, and repay events emitted by the program and aggregates them
-          by bank.
-        </p>
-        {error && (
-          <p className="text-sm text-red-600">
-            Bank data failed to load: {error}
-          </p>
-        )}
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-          <label className="flex-1 text-sm">
-            <span className="mb-1 block font-medium">Geyser API Key</span>
-            <input
-              type="text"
-              value={apiKey}
-              onChange={(event) => setApiKey(event.target.value)}
-              className="w-full px-3 py-2 border rounded"
-              placeholder="Paste your API key"
-              disabled={status === "connecting" || status === "connected"}
-            />
-          </label>
-          <div className="flex gap-2">
-            <button
-              onClick={startMonitoring}
-              className="px-4 py-2 bg-green-600 text-white rounded disabled:opacity-60"
-              disabled={
-                status === "connecting" ||
-                status === "connected" ||
-                !banks.length
-              }
-            >
-              Start Monitoring
-            </button>
-            <button
-              onClick={stopMonitoring}
-              className="px-4 py-2 bg-gray-200 text-gray-700 rounded disabled:opacity-60"
-              disabled={status === "idle"}
-            >
-              Stop
-            </button>
-          </div>
-        </div>
-        <div className="text-sm">
-          <span
-            className={
-              status === "connected"
-                ? "text-green-600"
-                : status === "error"
-                  ? "text-red-600"
-                  : "text-gray-600"
-            }
-          >
-            Status: {statusLabel}
-          </span>
-        </div>
-        {statusError && (
-          <div className="text-sm text-red-600">{statusError}</div>
-        )}
-        <div className="text-sm text-gray-600">
-          Observed events — Deposits: {aggregateCounts.deposit}, Borrows:{" "}
-          {aggregateCounts.borrow}, Withdrawals: {aggregateCounts.withdraw} (
-          {aggregateCounts.withdrawFlagged} withdraw-all), Repays:{" "}
-          {aggregateCounts.repay} ({aggregateCounts.repayFlagged} repay-all)
-        </div>
-        {lastEventDisplay && (
-          <div className="text-sm text-gray-600">
-            Last event: {lastEventDisplay}
-          </div>
-        )}
-      </section>
+  const statusTone = useMemo(() => {
+    switch (status) {
+      case "connected":
+        return "bg-cyan-500/20 text-cyan-200 ring-1 ring-cyan-500/40";
+      case "connecting":
+        return "bg-orange-500/20 text-orange-200 ring-1 ring-orange-500/40";
+      case "error":
+        return "bg-pink-500/20 text-pink-200 ring-1 ring-pink-500/40";
+      default:
+        return "bg-slate-900/60 text-cyan-200 ring-1 ring-slate-700/60";
+    }
+  }, [status]);
 
-      <section>
-        <BankEventStatsList banks={banks} stats={stats} />
-      </section>
+  const observedSummaries = useMemo(() => {
+    const withdrawDetail =
+      aggregateCounts.withdrawFlagged > 0
+        ? `${aggregateCounts.withdrawFlagged.toLocaleString()} withdraw-all`
+        : "No withdraw-all events";
+    const repayDetail =
+      aggregateCounts.repayFlagged > 0
+        ? `${aggregateCounts.repayFlagged.toLocaleString()} repay-all`
+        : "No repay-all events";
+
+    return [
+      {
+        key: "deposits",
+        label: "Deposits",
+        value: aggregateCounts.deposit,
+        detail: "Events observed",
+        accent: "from-cyan-400/60 via-blue-500/40 to-transparent",
+      },
+      {
+        key: "borrows",
+        label: "Borrows",
+        value: aggregateCounts.borrow,
+        detail: "Events observed",
+        accent: "from-blue-400/60 via-cyan-500/30 to-transparent",
+      },
+      {
+        key: "withdraws",
+        label: "Withdrawals",
+        value: aggregateCounts.withdraw,
+        detail: withdrawDetail,
+        accent: "from-pink-400/60 via-orange-400/30 to-transparent",
+      },
+      {
+        key: "repays",
+        label: "Repays",
+        value: aggregateCounts.repay,
+        detail: repayDetail,
+        accent: "from-orange-400/60 via-pink-500/30 to-transparent",
+      },
+    ];
+  }, [aggregateCounts]);
+
+  return (
+    <div className="relative isolate overflow-hidden rounded-3xl border border-cyan-500/30 bg-slate-950/80 px-6 py-8 text-cyan-100 shadow-[0_0_55px_rgba(14,165,233,0.25)] sm:px-10">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute -top-36 right-0 h-64 w-64 rounded-full bg-pink-500/25 blur-[140px]" />
+        <div className="absolute bottom-0 -left-24 h-72 w-72 rounded-full bg-cyan-500/25 blur-[160px]" />
+      </div>
+      <div className="relative z-10 space-y-10">
+        <section className="space-y-6">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight text-transparent bg-gradient-to-r from-cyan-300 via-pink-400 to-orange-300 bg-clip-text">
+              Geyser Event Monitor
+            </h1>
+            <p className="max-w-3xl text-sm text-cyan-100/70">
+              Paste your Geyser API key and press Start to subscribe to marginfi
+              lending account events. The monitor listens for deposit, borrow,
+              withdraw, and repay events emitted by the program and aggregates
+              them by bank in real time.
+            </p>
+          </div>
+
+          {error && (
+            <div className="rounded-xl border border-pink-500/40 bg-pink-500/10 px-4 py-3 text-sm text-pink-100">
+              Bank data failed to load: {error}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end">
+            <label className="flex-1 text-sm">
+              <span className="mb-2 block text-xs font-semibold uppercase tracking-[0.25em] text-cyan-300/80">
+                Geyser API Key
+              </span>
+              <input
+                type="text"
+                value={apiKey}
+                onChange={(event) => setApiKey(event.target.value)}
+                className="w-full rounded-xl border border-cyan-500/40 bg-slate-900/70 px-3 py-2 font-mono text-sm text-cyan-100 placeholder:text-cyan-200/30 focus:border-pink-400 focus:outline-none focus:ring-2 focus:ring-pink-400/50 disabled:cursor-not-allowed disabled:opacity-60"
+                placeholder="Paste your API key"
+                disabled={status === "connecting" || status === "connected"}
+              />
+            </label>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={startMonitoring}
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-cyan-500 via-blue-500 to-pink-500 px-5 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/40 transition hover:-translate-y-0.5 hover:shadow-pink-500/40 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={
+                  status === "connecting" ||
+                  status === "connected" ||
+                  !banks.length
+                }
+              >
+                Start Monitoring
+              </button>
+              <button
+                onClick={stopMonitoring}
+                className="inline-flex items-center justify-center rounded-full border border-pink-400/40 bg-slate-900/70 px-5 py-2 text-sm font-semibold text-pink-200 transition hover:border-pink-300 hover:text-pink-100 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={status === "idle"}
+              >
+                Stop
+              </button>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            <span
+              className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] ${statusTone} ${status === "connecting" ? "animate-pulse" : ""}`}
+            >
+              <span className="h-2 w-2 rounded-full bg-current" />
+              {statusLabel}
+            </span>
+            {statusError && (
+              <span className="text-pink-200/80">{statusError}</span>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-cyan-200/70">
+              Observed Events
+            </h2>
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              {observedSummaries.map((summary) => (
+                <div
+                  key={summary.key}
+                  className="relative overflow-hidden rounded-2xl border border-cyan-500/20 bg-slate-900/70 p-4 shadow-[0_0_25px_rgba(14,165,233,0.2)]"
+                >
+                  <div
+                    className={`pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${summary.accent}`}
+                  />
+                  <div className="text-xs font-semibold uppercase tracking-[0.25em] text-cyan-200/70">
+                    {summary.label}
+                  </div>
+                  <div className="mt-3 text-2xl font-semibold text-cyan-100 tabular-nums">
+                    {summary.value.toLocaleString()}
+                  </div>
+                  <div className="mt-1 text-xs text-cyan-200/60">
+                    {summary.detail}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {lastEventDetails && (
+            <div className="rounded-2xl border border-pink-500/30 bg-slate-900/70 p-5 shadow-[0_0_35px_rgba(236,72,153,0.25)]">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="space-y-2">
+                  <div className="text-xs font-semibold uppercase tracking-[0.3em] text-pink-300">
+                    Latest Event
+                  </div>
+                  <div className="text-lg font-semibold text-cyan-100">
+                    {lastEventDetails.kindLabel} for {lastEventDetails.bankLabel}
+                  </div>
+                  <div className="text-xs text-cyan-200/70">
+                    Slot {lastEventDetails.slot.toLocaleString()} •{" "}
+                    {lastEventDetails.timestampText}
+                  </div>
+                  <div className="font-mono text-[0.65rem] text-cyan-200/50">
+                    {lastEventDetails.bankKey}
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-2 text-right">
+                  <span className="font-mono text-2xl text-pink-200 tabular-nums min-w-[15ch]">
+                    {lastEventDetails.amount}
+                  </span>
+                  {lastEventDetails.flagged ? (
+                    <span className="text-xs text-orange-300">
+                      Withdraw/Repay All flagged
+                    </span>
+                  ) : (
+                    <span className="text-xs text-cyan-200/60">
+                      Standard event
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-cyan-200/70">
+              Bank Totals
+            </h2>
+            <p className="mt-1 text-xs text-cyan-200/50">
+              Banks are listed alphabetically. Use the search to quickly jump to
+              a specific token.
+            </p>
+          </div>
+          <BankEventStatsList banks={banks} stats={stats} />
+        </section>
+      </div>
     </div>
   );
+
 }


### PR DESCRIPTION
## Summary
- restyle the bank event monitor page with a dark cyan/pink theme, status chips, observed-event summary cards, and a richer latest-event callout
- present bank statistics in an alphabetized card grid with consistent 4-decimal token formatting and fixed-width amount displays
- add a reusable formatter that converts bigint token totals to 4-decimal strings based on mint decimals

## Testing
- npm run lint *(fails: existing @typescript-eslint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_b_68d382e37db083239ef811d14403ecc8