### PR TITLE
Revamp BankEventMonitorPage UI

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,38 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Marginfi Tools</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: [
+                "Inter",
+                "system-ui",
+                "-apple-system",
+                "BlinkMacSystemFont",
+                "Segoe UI",
+                "sans-serif",
+              ],
+              mono: [
+                "IBM Plex Mono",
+                "ui-monospace",
+                "SFMono-Regular",
+                "Menlo",
+                "Monaco",
+                "Consolas",
+                "Liberation Mono",
+                "Courier New",
+                "monospace",
+              ],
+            },
+          },
+        },
+      };
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/app/src/components/BankEventStatsList.tsx
+++ b/app/src/components/BankEventStatsList.tsx
@@ -9,35 +9,50 @@ interface BankEventStatsListProps {
   stats: Record<string, BankEventStats>;
 }
 
-const renderPrimary = (stat: EventTotals, decimals: number) => (
-  <div className="space-y-1">
-    <div className="font-mono text-sm">
-      {formatTokenAmount(stat.total, decimals)}
-    </div>
-    <div className="text-xs text-gray-500">
-      {stat.count} {stat.count === 1 ? "event" : "events"}
-    </div>
-    {stat.total !== 0n && (
-      <div className="text-[0.65rem] text-gray-400 font-mono">
-        raw: {stat.total.toString()}
-      </div>
-    )}
-  </div>
-);
+const formatAccumulatedAmount = (value: bigint, decimals: number) =>
+  formatTokenAmount(value, decimals, { fractionDigits: 4 });
 
-const renderFlagged = (stat: EventTotals, decimals: number) => (
-  <div className="space-y-1">
-    <div className="font-mono text-sm">
-      {stat.flaggedCount > 0
-        ? formatTokenAmount(stat.flaggedTotal, decimals)
-        : "0"}
+const formatFlaggedAmount = (stat: EventTotals, decimals: number) =>
+  stat.flaggedCount > 0
+    ? formatTokenAmount(stat.flaggedTotal, decimals, { fractionDigits: 4 })
+    : "0.0000";
+
+interface StatTileProps {
+  label: string;
+  amount: string;
+  count: number;
+  accentClass: string;
+  rawValue?: string;
+  className?: string;
+}
+
+const StatTile: React.FC<StatTileProps> = ({
+  label,
+  amount,
+  count,
+  accentClass,
+  rawValue,
+  className,
+}) => (
+  <div
+    className={`rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4 shadow-inner transition duration-300 hover:border-cyan-400/40 ${className ?? ""}`}
+  >
+    <div className="flex items-center justify-between text-[0.7rem] uppercase tracking-wide text-slate-400">
+      <span>{label}</span>
+      <span className="text-slate-500">
+        {count} {count === 1 ? "event" : "events"}
+      </span>
     </div>
-    <div className="text-xs text-gray-500">
-      {stat.flaggedCount} {stat.flaggedCount === 1 ? "event" : "events"}
+    <div className="mt-3 flex items-end justify-between gap-3">
+      <span
+        className={`min-w-[15ch] text-right font-mono text-lg leading-none ${accentClass}`}
+      >
+        {amount}
+      </span>
     </div>
-    {stat.flaggedCount > 0 && (
-      <div className="text-[0.65rem] text-gray-400 font-mono">
-        raw: {stat.flaggedTotal.toString()}
+    {rawValue && (
+      <div className="mt-3 break-all text-[0.65rem] font-mono text-slate-500">
+        raw: {rawValue}
       </div>
     )}
   </div>
@@ -60,88 +75,173 @@ export const BankEventStatsList: React.FC<BankEventStatsListProps> = ({
   }, [banks, search]);
 
   return (
-    <div className="space-y-4">
-      <button
-        onClick={() => setCollapsed((current) => !current)}
-        className="px-4 py-2 bg-blue-600 text-white rounded"
-      >
-        {collapsed ? "Show Banks" : "Hide Banks"}
-      </button>
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <button
+          onClick={() => setCollapsed((current) => !current)}
+          className="rounded-full border border-cyan-500/40 bg-cyan-500/10 px-5 py-2 text-sm font-semibold text-cyan-200 shadow-md transition hover:border-pink-400/50 hover:text-pink-200"
+        >
+          {collapsed ? "Show Banks" : "Hide Banks"}
+        </button>
+
+        <span className="text-xs uppercase tracking-[0.2em] text-slate-500">
+          {filteredBanks.length} bank{filteredBanks.length === 1 ? "" : "s"}
+        </span>
+      </div>
 
       {!collapsed && (
-        <div className="space-y-3">
-          <input
-            type="text"
-            placeholder="Search by token name…"
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            className="w-full px-3 py-2 border rounded"
-          />
-
-          <div className="overflow-x-auto">
-            <table className="min-w-full border rounded bg-white">
-              <thead className="bg-gray-100 text-left text-xs uppercase tracking-wide text-gray-600">
-                <tr>
-                  <th className="px-3 py-2">Token</th>
-                  <th className="px-3 py-2">Deposits</th>
-                  <th className="px-3 py-2">Borrows</th>
-                  <th className="px-3 py-2">Withdrawals</th>
-                  <th className="px-3 py-2">Withdraw All*</th>
-                  <th className="px-3 py-2">Repays</th>
-                  <th className="px-3 py-2">Repay All*</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredBanks.length === 0 && (
-                  <tr>
-                    <td
-                      colSpan={7}
-                      className="px-3 py-6 text-center text-sm text-gray-500"
-                    >
-                      No banks match your search.
-                    </td>
-                  </tr>
-                )}
-
-                {filteredBanks.map((bank) => {
-                  const key = bank.bankPubkey.toBase58();
-                  const bankStats = stats[key] ?? createEmptyBankEventStats();
-                  const decimals = bank.bankAcc?.mintDecimals ?? 0;
-
-                  return (
-                    <tr key={key} className="border-t">
-                      <td className="px-3 py-2 font-medium text-sm">
-                        <div>{bank.tokenName}</div>
-                        <div className="text-xs text-gray-500 font-mono">
-                          {key}
-                        </div>
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderPrimary(bankStats.deposit, decimals)}
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderPrimary(bankStats.borrow, decimals)}
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderPrimary(bankStats.withdraw, decimals)}
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderFlagged(bankStats.withdraw, decimals)}
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderPrimary(bankStats.repay, decimals)}
-                      </td>
-                      <td className="px-3 py-2 align-top">
-                        {renderFlagged(bankStats.repay, decimals)}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+        <div className="space-y-6">
+          <div className="relative">
+            <div className="pointer-events-none absolute inset-y-0 left-0 flex w-10 items-center justify-center text-cyan-400">
+              🔍
+            </div>
+            <input
+              type="text"
+              placeholder="Search by token name…"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              className="w-full rounded-2xl border border-slate-800/70 bg-slate-900/60 px-12 py-3 text-sm text-slate-100 shadow-inner outline-none transition focus:border-pink-500/60 focus:ring-2 focus:ring-pink-500/30"
+            />
           </div>
 
-          <p className="text-xs text-gray-500">
+          {filteredBanks.length === 0 ? (
+            <div className="rounded-3xl border border-dashed border-slate-700/60 bg-slate-900/60 p-8 text-center text-sm text-slate-400">
+              No banks match your search.
+            </div>
+          ) : (
+            <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+              {filteredBanks.map((bank) => {
+                const key = bank.bankPubkey.toBase58();
+                const bankStats = stats[key] ?? createEmptyBankEventStats();
+                const decimals = bank.bankAcc?.mintDecimals ?? 0;
+                const totalEvents =
+                  bankStats.deposit.count +
+                  bankStats.borrow.count +
+                  bankStats.withdraw.count +
+                  bankStats.repay.count;
+
+                return (
+                  <div
+                    key={key}
+                    className="group relative overflow-hidden rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-5 shadow-[0_12px_40px_rgba(8,47,73,0.35)] transition duration-300 hover:-translate-y-1 hover:border-pink-400/50"
+                  >
+                    <div className="pointer-events-none absolute inset-0 opacity-0 transition duration-300 group-hover:opacity-100">
+                      <div className="absolute inset-0 bg-gradient-to-br from-cyan-500/15 via-transparent to-pink-500/20" />
+                    </div>
+                    <div className="relative space-y-5">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <h3 className="text-lg font-semibold tracking-wide text-cyan-200">
+                            {bank.tokenName}
+                          </h3>
+                          <div className="mt-1 break-all font-mono text-[0.7rem] text-slate-500">
+                            {key}
+                          </div>
+                        </div>
+                        <span className="rounded-full border border-pink-500/40 bg-pink-500/10 px-3 py-1 text-[0.65rem] uppercase tracking-widest text-pink-200">
+                          {totalEvents} evt
+                        </span>
+                      </div>
+
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <StatTile
+                          label="Deposits"
+                          amount={formatAccumulatedAmount(
+                            bankStats.deposit.total,
+                            decimals,
+                          )}
+                          count={bankStats.deposit.count}
+                          accentClass="text-cyan-300"
+                          rawValue={
+                            bankStats.deposit.total !== 0n
+                              ? bankStats.deposit.total.toString()
+                              : undefined
+                          }
+                        />
+                        <StatTile
+                          label="Borrows"
+                          amount={formatAccumulatedAmount(
+                            bankStats.borrow.total,
+                            decimals,
+                          )}
+                          count={bankStats.borrow.count}
+                          accentClass="text-orange-300"
+                          rawValue={
+                            bankStats.borrow.total !== 0n
+                              ? bankStats.borrow.total.toString()
+                              : undefined
+                          }
+                        />
+                        <StatTile
+                          label="Withdrawals"
+                          amount={formatAccumulatedAmount(
+                            bankStats.withdraw.total,
+                            decimals,
+                          )}
+                          count={bankStats.withdraw.count}
+                          accentClass="text-pink-300"
+                          rawValue={
+                            bankStats.withdraw.total !== 0n
+                              ? bankStats.withdraw.total.toString()
+                              : undefined
+                          }
+                        />
+                        <StatTile
+                          label="Repays"
+                          amount={formatAccumulatedAmount(
+                            bankStats.repay.total,
+                            decimals,
+                          )}
+                          count={bankStats.repay.count}
+                          accentClass="text-blue-300"
+                          rawValue={
+                            bankStats.repay.total !== 0n
+                              ? bankStats.repay.total.toString()
+                              : undefined
+                          }
+                        />
+                      </div>
+
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <StatTile
+                          label="Withdraw All*"
+                          amount={formatFlaggedAmount(
+                            bankStats.withdraw,
+                            decimals,
+                          )}
+                          count={bankStats.withdraw.flaggedCount}
+                          accentClass="text-pink-200"
+                          rawValue={
+                            bankStats.withdraw.flaggedCount > 0
+                              ? bankStats.withdraw.flaggedTotal.toString()
+                              : undefined
+                          }
+                          className="hover:border-pink-400/60"
+                        />
+                        <StatTile
+                          label="Repay All*"
+                          amount={formatFlaggedAmount(
+                            bankStats.repay,
+                            decimals,
+                          )}
+                          count={bankStats.repay.flaggedCount}
+                          accentClass="text-orange-200"
+                          rawValue={
+                            bankStats.repay.flaggedCount > 0
+                              ? bankStats.repay.flaggedTotal.toString()
+                              : undefined
+                          }
+                          className="hover:border-orange-400/60"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <p className="text-xs text-slate-500">
             * Withdraw All / Repay All events are tracked separately because the
             reported amount may not reflect the final settled amount.
           </p>

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,68 +1,25 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color-scheme: dark;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(14, 116, 144, 0.25), rgba(15, 23, 42, 0.9) 45%, rgba(2, 6, 23, 1));
+  color: #e2e8f0;
+  font-family: "Inter", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", sans-serif;
+}
+
+#root {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+code,
+pre,
+.mono {
+  font-family: "IBM Plex Mono", "ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
 }

--- a/app/src/lib/format.ts
+++ b/app/src/lib/format.ts
@@ -1,28 +1,32 @@
 import BigNumber from "bignumber.js";
 
+interface FormatTokenAmountOptions {
+  maxFractionDigits?: number;
+  fractionDigits?: number;
+}
+
 export const formatTokenAmount = (
   raw: bigint,
   decimals: number,
-  options?: { maxFractionDigits?: number }
+  options?: FormatTokenAmountOptions,
 ): string => {
   if (raw === 0n) {
+    if (options?.fractionDigits !== undefined) {
+      if (options.fractionDigits === 0) {
+        return "0";
+      }
+      return `0.${"0".repeat(options.fractionDigits)}`;
+    }
     return "0";
   }
 
   const amount = new BigNumber(raw.toString());
-  if (decimals === 0) {
-    return amount.toFormat(0, BigNumber.ROUND_DOWN, {
-      groupSeparator: ",",
-      decimalSeparator: ".",
-      groupSize: 3,
-    });
-  }
-
   const divisor = new BigNumber(10).pow(decimals);
-  const decimalPlaces = Math.min(
-    decimals,
-    options?.maxFractionDigits ?? 6
-  );
+  const decimalPlaces =
+    options?.fractionDigits ??
+    (decimals === 0
+      ? 0
+      : Math.min(decimals, options?.maxFractionDigits ?? 6));
 
   return amount
     .dividedBy(divisor)

--- a/app/src/pages/BankEventMonitorPage.tsx
+++ b/app/src/pages/BankEventMonitorPage.tsx
@@ -639,36 +639,43 @@ export function BankEventMonitorPage({
   }, [status]);
 
   return (
-    <div className="space-y-6">
-      <section className="space-y-3">
-        <h1 className="text-2xl font-semibold">Geyser Event Monitor</h1>
-        <p className="text-sm text-gray-600">
-          Paste your Geyser API key and press Start to subscribe to marginfi
-          lending account events. The monitor listens for deposit, borrow,
-          withdraw, and repay events emitted by the program and aggregates them
-          by bank.
-        </p>
-        {error && (
-          <p className="text-sm text-red-600">
-            Bank data failed to load: {error}
+    <div className="space-y-10 rounded-3xl border border-cyan-500/20 bg-slate-950/95 p-6 text-slate-100 shadow-[0_0_60px_rgba(8,47,73,0.45)] md:p-10">
+      <section className="space-y-6">
+        <div className="space-y-4">
+          <h1 className="text-3xl font-semibold tracking-wide text-cyan-200">
+            Geyser Event Monitor
+          </h1>
+          <p className="max-w-3xl text-sm leading-relaxed text-slate-400">
+            Paste your Geyser API key and press Start to subscribe to marginfi
+            lending account events. The monitor listens for deposit, borrow,
+            withdraw, and repay events emitted by the program and aggregates
+            them by bank in real-time.
           </p>
-        )}
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-          <label className="flex-1 text-sm">
-            <span className="mb-1 block font-medium">Geyser API Key</span>
+          {error && (
+            <p className="rounded-2xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+              Bank data failed to load: {error}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end">
+          <label className="flex-1 text-sm text-slate-300">
+            <span className="mb-2 block font-semibold uppercase tracking-widest text-cyan-200">
+              Geyser API Key
+            </span>
             <input
               type="text"
               value={apiKey}
               onChange={(event) => setApiKey(event.target.value)}
-              className="w-full px-3 py-2 border rounded"
+              className="w-full rounded-2xl border border-cyan-500/30 bg-slate-900/60 px-4 py-3 font-mono text-cyan-100 shadow-inner outline-none transition focus:border-pink-500/60 focus:ring-2 focus:ring-pink-500/30"
               placeholder="Paste your API key"
               disabled={status === "connecting" || status === "connected"}
             />
           </label>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-3">
             <button
               onClick={startMonitoring}
-              className="px-4 py-2 bg-green-600 text-white rounded disabled:opacity-60"
+              className="rounded-full bg-gradient-to-r from-cyan-500/80 via-pink-500/70 to-orange-400/80 px-6 py-2 text-sm font-semibold uppercase tracking-wide text-slate-950 shadow-lg transition hover:from-cyan-400 hover:via-pink-400 hover:to-orange-300 disabled:cursor-not-allowed disabled:opacity-40"
               disabled={
                 status === "connecting" ||
                 status === "connected" ||
@@ -679,38 +686,77 @@ export function BankEventMonitorPage({
             </button>
             <button
               onClick={stopMonitoring}
-              className="px-4 py-2 bg-gray-200 text-gray-700 rounded disabled:opacity-60"
+              className="rounded-full border border-slate-700/70 bg-slate-900/60 px-6 py-2 text-sm font-semibold uppercase tracking-wide text-slate-200 shadow-inner transition hover:border-pink-400/60 hover:text-pink-200 disabled:cursor-not-allowed disabled:opacity-40"
               disabled={status === "idle"}
             >
               Stop
             </button>
           </div>
         </div>
-        <div className="text-sm">
-          <span
-            className={
-              status === "connected"
-                ? "text-green-600"
-                : status === "error"
-                  ? "text-red-600"
-                  : "text-gray-600"
-            }
-          >
-            Status: {statusLabel}
+
+        <div className="flex flex-wrap items-center gap-4 text-sm">
+          <span className="rounded-full border border-slate-800/70 bg-slate-900/60 px-4 py-2 font-semibold uppercase tracking-widest text-slate-300">
+            Status:
+            <span
+              className={`ml-2 rounded-full px-3 py-1 text-xs font-semibold ${
+                status === "connected"
+                  ? "bg-cyan-500/20 text-cyan-200"
+                  : status === "error"
+                    ? "bg-red-500/20 text-red-200"
+                    : status === "connecting"
+                      ? "bg-orange-500/20 text-orange-200"
+                      : "bg-slate-700/60 text-slate-300"
+              }`}
+            >
+              {statusLabel}
+            </span>
           </span>
+          {statusError && (
+            <span className="text-sm text-red-200">{statusError}</span>
+          )}
         </div>
-        {statusError && (
-          <div className="text-sm text-red-600">{statusError}</div>
-        )}
-        <div className="text-sm text-gray-600">
-          Observed events — Deposits: {aggregateCounts.deposit}, Borrows:{" "}
-          {aggregateCounts.borrow}, Withdrawals: {aggregateCounts.withdraw} (
-          {aggregateCounts.withdrawFlagged} withdraw-all), Repays:{" "}
-          {aggregateCounts.repay} ({aggregateCounts.repayFlagged} repay-all)
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="rounded-2xl border border-cyan-500/30 bg-slate-900/60 p-4 shadow-inner">
+            <p className="text-xs uppercase tracking-wide text-slate-400">Deposits</p>
+            <p className="mt-2 font-mono text-2xl text-cyan-300">
+              {aggregateCounts.deposit.toLocaleString()}
+            </p>
+            <p className="text-[0.7rem] text-slate-500">events observed</p>
+          </div>
+          <div className="rounded-2xl border border-orange-500/30 bg-slate-900/60 p-4 shadow-inner">
+            <p className="text-xs uppercase tracking-wide text-slate-400">Borrows</p>
+            <p className="mt-2 font-mono text-2xl text-orange-300">
+              {aggregateCounts.borrow.toLocaleString()}
+            </p>
+            <p className="text-[0.7rem] text-slate-500">events observed</p>
+          </div>
+          <div className="rounded-2xl border border-pink-500/30 bg-slate-900/60 p-4 shadow-inner">
+            <p className="text-xs uppercase tracking-wide text-slate-400">Withdrawals</p>
+            <p className="mt-2 font-mono text-2xl text-pink-300">
+              {aggregateCounts.withdraw.toLocaleString()}
+            </p>
+            <p className="text-[0.7rem] text-slate-500">
+              {aggregateCounts.withdrawFlagged.toLocaleString()} withdraw-all
+            </p>
+          </div>
+          <div className="rounded-2xl border border-blue-500/30 bg-slate-900/60 p-4 shadow-inner">
+            <p className="text-xs uppercase tracking-wide text-slate-400">Repays</p>
+            <p className="mt-2 font-mono text-2xl text-blue-300">
+              {aggregateCounts.repay.toLocaleString()}
+            </p>
+            <p className="text-[0.7rem] text-slate-500">
+              {aggregateCounts.repayFlagged.toLocaleString()} repay-all
+            </p>
+          </div>
         </div>
+
         {lastEventDisplay && (
-          <div className="text-sm text-gray-600">
-            Last event: {lastEventDisplay}
+          <div className="rounded-3xl border border-cyan-500/30 bg-gradient-to-r from-cyan-500/20 via-slate-900/60 to-pink-500/20 px-5 py-4 text-sm text-slate-200 shadow-lg">
+            <span className="font-semibold uppercase tracking-widest text-cyan-200">
+              Last event
+            </span>
+            <div className="mt-2 text-slate-100">{lastEventDisplay}</div>
           </div>
         )}
       </section>


### PR DESCRIPTION
## Summary
- refresh the BankEventMonitorPage with a dark, neon-inspired layout, updated status display, and highlighted aggregate metrics
- replace the tabular bank stats with an alphabetical grid of cards that keeps amounts in fixed-width boxes and adds a styled search experience
- extend token formatting utilities so accumulated totals render as 4-decimal values instead of native token units

## Testing
- yarn lint *(fails: repository already has widespread prettier warnings outside this change)*

------
https://chatgpt.com/codex/tasks/task_b_68d382e37db083239ef811d14403ecc8