### PR TITLE
fix staging bank metadata and validate rpc/wallet env

### DIFF
--- a/accounts/get-account.ts
+++ b/accounts/get-account.ts
@@ -25,8 +25,8 @@ async function main() {
   const accountPubkey = new PublicKey(argv.account);
   const program = getMarginfiProgram(argv.env as Environment);
 
-  // Fetch bank metadata
-  const bankMetadata = await getBankMetadata();
+  // Fetch bank metadata (must match --env so staging uses correct symbol cache)
+  const bankMetadata = await getBankMetadata(argv.env as Environment);
 
   let acc = await program.account.marginfiAccount.fetch(accountPubkey);
   let balances = acc.lendingAccount.balances;

--- a/banks/get-bank-accounts.ts
+++ b/banks/get-bank-accounts.ts
@@ -55,7 +55,7 @@ async function main() {
     .parseSync();
 
   const program = getMarginfiProgram(argv.env as Environment);
-  const bankMetadata = await getBankMetadata();
+  const bankMetadata = await getBankMetadata(argv.env as Environment);
 
   let bankPubkey: PublicKey;
   if (argv.address) {

--- a/env.template
+++ b/env.template
@@ -1,8 +1,8 @@
 # Solana RPC endpoint URL, usually with access api token
 PRIVATE_RPC_ENDPOINT="https://mrgn.rpcpool.com/<API_TOKEN>"
 
-# The Solana wallet that will be used to sign transactions and pay fees
-MARGINFI_WALLET=home/user/keys/wallet.json
+# The Solana wallet that will be used to sign transactions and pay fees (absolute path, or e.g. ~/keys/wallet.json)
+MARGINFI_WALLET=~/keys/wallet.json
 
 MARGINFI_ENV="production"
 MARGINFI_PROGRAM_ID=MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -27,8 +27,20 @@ export const getConfig = (env: Environment = "production", groupAddress?: string
 
 export const getMarginfiProgram = (env: Environment = "production") => {
   const config = getConfig(env);
-  const connection = new Connection(process.env.PRIVATE_RPC_ENDPOINT, "confirmed");
-  const wallet = loadKeypairFromFile(process.env.MARGINFI_WALLET);
+  const rpc = process.env.PRIVATE_RPC_ENDPOINT?.trim();
+  if (!rpc) {
+    throw new Error(
+      "PRIVATE_RPC_ENDPOINT is missing or empty. Copy env.template to .env and set your Solana RPC URL.",
+    );
+  }
+  const walletPath = process.env.MARGINFI_WALLET?.trim();
+  if (!walletPath) {
+    throw new Error(
+      "MARGINFI_WALLET is missing or empty. Set it to the path of your keypair JSON (see env.template).",
+    );
+  }
+  const connection = new Connection(rpc, "confirmed");
+  const wallet = loadKeypairFromFile(walletPath);
 
   MARGINFI_IDL.address = config.PROGRAM_ID;
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import path from "path";
+import { homedir } from "os";
 import dotenv from "dotenv";
 import BigNumber from "bignumber.js";
 import {
@@ -42,8 +43,24 @@ export const u32_MAX: number = 4294967295;
 
 dotenv.config();
 
+/** Resolves `~` and relative paths for keypair paths from `.env`. */
+export function resolveUserPath(filePath: string): string {
+  const p = filePath.trim();
+  if (!p) {
+    throw new Error("Path is empty.");
+  }
+  if (p.startsWith("~/")) {
+    return path.join(homedir(), p.slice(2));
+  }
+  if (p === "~") {
+    return homedir();
+  }
+  return path.isAbsolute(p) ? p : path.resolve(process.cwd(), p);
+}
+
 export function loadKeypairFromFile(filePath: string): Keypair {
-  const keyData = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  const resolved = resolveUserPath(filePath);
+  const keyData = JSON.parse(fs.readFileSync(resolved, "utf-8"));
   return Keypair.fromSecretKey(new Uint8Array(keyData));
 }
 


### PR DESCRIPTION
## Summary

- **Staging bug:** \ccounts:get\ and \anks:get-accounts\ called \getBankMetadata()\ without the CLI \--env\ value, so \--env staging\ still loaded **production** bank symbol metadata from the CDN. That could show wrong token symbols and break \--symbol\ lookups against staging banks.
- **Config UX:** \getMarginfiProgram\ now fails fast with clear messages when \PRIVATE_RPC_ENDPOINT\ or \MARGINFI_WALLET\ is missing, and the RPC URL is trimmed (avoids subtle connection issues from stray whitespace).
- **Wallet path:** \loadKeypairFromFile\ resolves \~\ and relative paths via new \
esolveUserPath\, so \.env\ can use \~/keys/wallet.json\ on any OS. \env.template\ was updated to match.

made by mooncitydev
